### PR TITLE
Remove sunlight api from repo

### DIFF
--- a/api.py
+++ b/api.py
@@ -3,7 +3,14 @@ import csv
 from legislators.models import Legislator
 from bills.models import Bill
 
-SUNLIGHT_API_KEY='6b879d65c49742058a88a0b955b3f172'
+try:
+    from grassroots.settings.local import SUNLIGHT_API_KEY
+except ImportError:
+    print('Sunlight API key required. Please obtain an API key from '
+          'https://sunlightfoundation.com/api/accounts/register/ and place it in /grassroots/settings/local.py '
+          '(See /grassroots/settings/local.py.example for an example or consult the wiki for more information).')
+    raise
+
 BASE_API_STR = 'http://congress.api.sunlightfoundation.com/'
 
 def query_api(query, page):

--- a/grassroots/settings/local.py.example
+++ b/grassroots/settings/local.py.example
@@ -1,3 +1,5 @@
 # If local.py is present, any settings in it will override those in base.py and dev.py.
 # Use this for any settings that are specific to this one installation, such as developer API keys.
 # local.py should not be checked in to version control.
+
+SUNLIGHT_API_KEY = 'Get your API key from https://sunlightfoundation.com/api/accounts/register/'


### PR DESCRIPTION
Moved SUNLIGHT_API_KEY parameter out of api.py and into local.py. Added instructions on where to get the API key in local.py.example. (https://tree.taiga.io/project/mekhami-grassroots/us/12)
